### PR TITLE
make infrastructure repo public

### DIFF
--- a/repos/infrastructure.yml
+++ b/repos/infrastructure.yml
@@ -1,7 +1,6 @@
 name: infrastructure
 description: |
   Automation stack for the Concourse project's infrastructure.
-private: true
 has_issues: true
 has_projects: true
 has_wiki: true


### PR DESCRIPTION
This repo should be made public so that non-infrastructure team members view it and submit PRs. It was always intended to be public someday, so now seems like a good time. The repo does not contain any sensitive information and may be useful to the general public as a reference.
