### PR TITLE
add deploy key for ci repo

### DIFF
--- a/repos/ci.yml
+++ b/repos/ci.yml
@@ -7,3 +7,8 @@ description: |
 has_issues: true
 has_projects: true
 has_wiki: true
+
+deploy_keys:
+- title: ci
+  public_key: "ecdsa-sha2-nistp384 AAAAE2VjZHNhLXNoYTItbmlzdHAzODQAAAAIbmlzdHAzODQAAABhBMeRfBQR43pD9VMR5PZPamhlMT4iEW5VgG2FWHgIbDeDYY13yCe2j0FfkrpHRGD1qScOx+xmqXHe4yZwb5+i4tnUOzhq8hT7c5vR4HWvxCDg52qPnrdKyFu9PnCjgdHd0Q=="
+  writable: true


### PR DESCRIPTION
at least for now, this key will be used to dynamically "pin" the
resource type versions by modifying the pipeline definition to add a
semver constraint to each resource type after releasing for the first
time - see concourse/ci#399 for more details

Signed-off-by: Aidan Oldershaw <aoldershaw@pivotal.io>