### PR TITLE
add oci-build-task repo

### DIFF
--- a/repos/oci-build-task.yml
+++ b/repos/oci-build-task.yml
@@ -1,0 +1,4 @@
+name: oci-build-task
+description: a Concourse task for building OCI images
+topics: [docker, golang, concourse, oci, oci-image, buildkit, concourse-task]
+has_issues: true

--- a/teams/maintainers.yml
+++ b/teams/maintainers.yml
@@ -70,6 +70,11 @@ repos:
 - datadog-event-resource
 - mock-resource
 
+# officially supported generic, reusable tasks
+#
+# these should be converted to Prototypes in the future
+- oci-build-task
+
 discord:
   role: maintainers
   color: 0xf8c300


### PR DESCRIPTION
manually transferred the repo already, this just gets the governance repo in sync