### PR TITLE
Add David Symons to contributors

### DIFF
--- a/contributors/multimac.yml
+++ b/contributors/multimac.yml
@@ -1,0 +1,4 @@
+name: David Symons
+github: multimac
+discord: 'multimac#2639'
+email: david@symons.io


### PR DESCRIPTION
Hey there, figured it's about time I joined the Concourse contributors.

I'm currently working on incorporating a new Kubernetes runtime into Concourse and would specifically love the ability to resurrect the `k8s-runtime` channel there to spark discussion around a proposed solution, its limitations, and the other work needed to get it to GA.