### PR TITLE
add components team

### DIFF
--- a/teams/components.yml
+++ b/teams/components.yml
@@ -9,6 +9,8 @@ members:
   - taylorsilva
 
 responsibilities:
+  - assist with triaging issues reported by users
+  - assist with triaging pull requests opened by other contributors
   - https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
 
 repo_permission: triage

--- a/teams/components.yml
+++ b/teams/components.yml
@@ -6,6 +6,7 @@ purpose: |
 
 members:
   - lrstanley
+  - taylorsilva
 
 responsibilities:
   - https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md

--- a/teams/components.yml
+++ b/teams/components.yml
@@ -1,0 +1,40 @@
+name: components
+
+purpose: |
+  A team for contributors assisting with triaging resource and reusable
+  task repositories.
+
+members:
+  - lrstanley
+
+responsibilities:
+  - https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
+
+repo_permission: triage
+repos:
+  # core resource types
+  - bosh-io-release-resource
+  - bosh-io-stemcell-resource
+  - datadog-event-resource
+  - docker-image-resource
+  - git-resource
+  - github-release-resource
+  - hg-resource
+  - mock-resource
+  - pool-resource
+  - registry-image-resource
+  - s3-resource
+  - semver-resource
+  - time-resource
+  - tracker-resource
+
+  # officially supported generic, reusable tasks
+  #
+  # these should be converted to Prototypes in the future
+  - oci-build-task
+
+discord:
+  role: components
+  color: 0xe69138
+  priority: 10
+  sticky: false


### PR DESCRIPTION
This PR adds an additional team called "components", that is similar to "all", however is specifically for all resource and reusable task repositories. Currently, triage is only given to the `concourse` repo, and my goal is to allow people to help triage with the resource/task repositories, as these often see issues go quite stale.

Though I'm the first one, and the readme mentions the following:

> A team with only one member is probably not a good sign, so try to recruit folks during this stage.

It does look like there may have been [previous ideas](https://github.com/concourse/governance/blob/master/teams/maintainers.yml#L51-L76) of having a team specific to resources/types, though I think that may have been more specific to maintainers of those repositories, not necessarily _just_ triage permissions. Others may be interested in being included in this as well.

Other ideas:

- Add `triage` permissions on team `all`, for all resource and task repositories.
  - This would be ideal, and not need a new team.
  - Downside is many contributors may never bother reviewing these repositories, so it would be giving elevated access (though not much) where it may be unused.
- New team, however with elevated (specifically maintainer or similar) permissions.
  - I think this would mean that the repositories can be removed from the maintainers team, and added to the components list.
  - This means the list of maintainers would be duplicated, as the current `maintainers` team would likely always be in both.
  - With this approach, could possibly update all `CODEOWNERS` files for those repos to make things more consistent. I see `CODEOWNERS` for the resource/task repositories are all over the place right now.
  - Not sure how I would fit into this, as I suspect I probably don't need elevated permissions past triage. Just looking to help, and past the `concourse` repo, there isn't much else right now 😀
- Alternatively, change nothing -- I'll just bug people to open and close issues 😁

related issue: https://github.com/concourse/governance/issues/83 (re: @taylorsilva, as well as @vito who originally added the TODO)