### PR TITLE
Remove repos that were moved to the vmware-archive org

### DIFF
--- a/repos/brand.yml
+++ b/repos/brand.yml
@@ -1,6 +1,0 @@
-name: brand
-description: Design system of components and patterns
-topics: []
-has_issues: true
-has_projects: true
-has_wiki: true

--- a/repos/csi-driver-host-path.yml
+++ b/repos/csi-driver-host-path.yml
@@ -1,7 +1,0 @@
-name: csi-driver-host-path
-description: A sample (non-production) CSI Driver that creates a local directory as
-  a volume on a single node
-topics: []
-has_issues: false
-has_projects: true
-has_wiki: true

--- a/repos/csi-driver-image-populator.yml
+++ b/repos/csi-driver-image-populator.yml
@@ -1,6 +1,0 @@
-name: csi-driver-image-populator
-description: CSI driver that uses a container image as a volume
-topics: []
-has_issues: false
-has_projects: true
-has_wiki: true

--- a/repos/drills.yml
+++ b/repos/drills.yml
@@ -1,6 +1,0 @@
-name: drills
-description: exercising longevity and upgrade paths
-topics: []
-has_issues: true
-has_projects: true
-has_wiki: true

--- a/repos/go-archive.yml
+++ b/repos/go-archive.yml
@@ -1,6 +1,0 @@
-name: go-archive
-description: Utilities for extracting and compressing tgz and zip files.
-topics: []
-has_issues: true
-has_projects: true
-has_wiki: true

--- a/repos/lfs-test-repo.yml
+++ b/repos/lfs-test-repo.yml
@@ -1,6 +1,0 @@
-name: lfs-test-repo
-description: this repo is a fixture for testing the git resource's LFS functionality
-topics: []
-has_issues: true
-has_projects: true
-has_wiki: true

--- a/repos/voyager.yml
+++ b/repos/voyager.yml
@@ -1,6 +1,0 @@
-name: voyager
-description: A database migration library that supports Go and SQL migrations.
-topics: []
-has_issues: true
-has_projects: true
-has_wiki: true


### PR DESCRIPTION
Not sure what process in vmware did this, or why it didn't affect all
repos that are currently archived (e.g. baggageclaim is still in the
Concourse org but is archived).

This may have been messing up membership access for new users as well.
One user on Discord, jphan, reported that we kept getting added then
removed from the org. Not sure if this will fix it. One problem at a
time.