### PR TITLE
at least I hope that fixes the issue...

### DIFF
--- a/contributors/caprowni.yml
+++ b/contributors/caprowni.yml
@@ -1,3 +1,3 @@
 name: Liam Caproni
-github: caprowni
+github: Caprowni
 discord: caprowni#0953


### PR DESCRIPTION
tests are showing the "Caprowni", with a capital 'c' is part of the org
and should NOT be, and that "caprowni", lowercase 'c', is not part of
the org and should be.

Signed-off-by: Taylor Silva <dev@taydev.net>