### PR TITLE
Correct the Discord tag for ConnorWidtfeldt

### DIFF
--- a/contributors/ConnorWidtfeldt.yml
+++ b/contributors/ConnorWidtfeldt.yml
@@ -1,3 +1,3 @@
 name: Connor Widtfeldt
 github: ConnorWidtfeldt
-discord: Arbiter#4101
+discord: Arbiter#4104


### PR DESCRIPTION
This is correcting a gaffe of mine. I should have just copied my Discord username by clicking on it, but I didn't know I could at the time. So instead, I just typed it as I saw it, and the four looked like a one to me, so I did 4101 instead of 4104. My apologies.