### PR TITLE
Add dtimm to infrastructure team

### DIFF
--- a/teams/infrastructure.yml
+++ b/teams/infrastructure.yml
@@ -15,6 +15,7 @@ members:
 - clarafu
 - xtremerui
 - taylorsilva
+- dtimm
 
 repos:
 - infrastructure


### PR DESCRIPTION
David Timm is on the VMware PPE team that contributes to Concourse