### PR TITLE
remove clarafu from security;remove Caprowni;

### DIFF
--- a/contributors/caprowni.yml
+++ b/contributors/caprowni.yml
@@ -1,3 +1,0 @@
-name: Liam Caproni
-github: Caprowni
-discord: caprowni#0953

--- a/teams/security.yml
+++ b/teams/security.yml
@@ -15,7 +15,6 @@ members:
 - scottietremendous
 - chenbh
 - taylorsilva
-- clarafu
 - xtremerui
 
 requires_email: true


### PR DESCRIPTION
reason:

clarafu doesn't have an email configured for security team 

Caprowni is not in Concourse org anymore

above cases are failing github action tests

Signed-off-by: Rui Yang <ruiya@vmware.com>