### PR TITLE
onboard PPE team to governance teams

### DIFF
--- a/teams/community.yml
+++ b/teams/community.yml
@@ -20,6 +20,11 @@ members:
 - xtremerui
 - clarafu
 - navdeep-pama
+- dtimm
+- markstokan
+- ram-pivot
+- syslxg
+- staylor14
 
 repos:
 - docs

--- a/teams/infrastructure.yml
+++ b/teams/infrastructure.yml
@@ -18,6 +18,8 @@ members:
 - dtimm
 - markstokan
 - ram-pivot
+- syslxg
+- staylor14
 
 repos:
 - infrastructure

--- a/teams/security.yml
+++ b/teams/security.yml
@@ -16,6 +16,11 @@ members:
 - chenbh
 - taylorsilva
 - xtremerui
+- dtimm
+- markstokan
+- ram-pivot
+- syslxg
+- staylor14
 
 requires_email: true
 


### PR DESCRIPTION
All PPE team members who have been onboarded to Concourse as contributors should be in the following teams:

* infrastructure
* maintainers
* security